### PR TITLE
increase correctness of responses to missing authorisation headers

### DIFF
--- a/assets/authentication.py
+++ b/assets/authentication.py
@@ -120,3 +120,10 @@ class OAuth2TokenAuthentication(BaseAuthentication):
             return None
 
         return token
+
+    def authenticate_header(self, request):
+        """
+        Return a string used to populate the WWW-Authenticate header for a HTTP 401 response.
+
+        """
+        return 'Bearer'

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -107,7 +107,7 @@ class APIViewsTests(TestCase):
     def assert_no_auth_fails(self, request_cb):
         """Passing no authorisation fails."""
         self.mock_authenticate.return_value = None
-        self.assertEqual(request_cb().status_code, 403)
+        self.assertEqual(request_cb().status_code, 401)
 
     def assert_no_scope_fails(self, request_cb):
         """Passing authorisation with incorrect scopes fail."""

--- a/assets/views.py
+++ b/assets/views.py
@@ -12,7 +12,7 @@ from .models import Asset
 from .permissions import HasScopesPermission
 from .serializers import AssetSerializer
 
-REQUIRED_SCOPES = ['lookup:anonymous', 'assetregister']
+REQUIRED_SCOPES = ['assetregister']
 """
 List of OAuth2 scopes required by this client.
 


### PR DESCRIPTION
There is a difference between "I need some credentials, you've not given me any" and "I accept your credentials but you do not have permission to do this". In HTTP this is 401 versus 403. Previously we were returning 403 for all responses. Update the authorisation class to return a 401 if the authorisation token is not present and set the WWW-Authentication header. This behaviour is mandated by some frontend client code which uses a 401 response to detect token expiry.