### PR TITLE
do not use annotated Asset model in admin

### DIFF
--- a/assets/admin.py
+++ b/assets/admin.py
@@ -3,7 +3,13 @@ from assets.models import Asset
 
 
 class AssetAdmin(admin.ModelAdmin):
-    list_fields = ('name', 'department', 'owner')
+    exclude = ('created_at', 'updated_at')
+    list_display = ('name', 'department', 'owner')
+
+    def get_queryset(self, request):
+        # We use the "base" queryset here because the admin does not like the is_complete
+        # annotation.
+        return Asset.objects.get_base_queryset()
 
 
 admin.site.register(Asset, AssetAdmin)

--- a/assets/models.py
+++ b/assets/models.py
@@ -10,7 +10,7 @@ class AssetManager(models.Manager):
     annotation reflects whether the asset record is "complete" as defined in the requirements."""
     def get_queryset(self):
         """A QuerySet to add an annotation to specify if an Asset is complete or not"""
-        return super().get_queryset().annotate(is_complete=Case(When(Q(
+        return self.get_base_queryset().annotate(is_complete=Case(When(Q(
             Q(name__isnull=False),
             Q(department__isnull=False),
             Q(purpose__isnull=False),
@@ -31,6 +31,14 @@ class AssetManager(models.Manager):
             Q(~Q(storage_format__contains="digital") |
               Q(Q(storage_format__contains="digital"), ~Q(digital_storage_security=[])))),
             then=Value(True)), default=Value(False), output_field=BooleanField()))
+
+    def get_base_queryset(self):
+        """
+        Return the original un-annotated queryset. Useful when the is_complete annotation is not
+        required.
+
+        """
+        return super().get_queryset()
 
 
 class Asset(models.Model):

--- a/assets/tests/test_admin.py
+++ b/assets/tests/test_admin.py
@@ -1,0 +1,19 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from assets.models import Asset
+
+
+class AdminViewsTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.asset = Asset.objects.create(name='foo')
+        self.superuser = get_user_model().objects.create_user(
+            username='testing', is_staff=True, is_superuser=True)
+
+    def test_index(self):
+        """Viewing the assets index in admin should be possible."""
+        self.client.force_login(self.superuser)
+        r = self.client.get(reverse('admin:assets_asset_changelist'))
+        self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
The admin interface does not like the cleverness of annotating objects
with the is_complete annotation. Provide a mechanism to get the original
queryset and configure the admin to use it.

Closes #5.