### PR TITLE
tox: add "makemigrations" env

### DIFF
--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -62,6 +62,10 @@ flake8
 collectstatic
     Collect static files used by Django to the ``build/static/`` directory.
 
+makemigrations
+    Run the "makemigrations" Django command to examine models for changes.
+    Useful if you don't have a virtualenv set up in your local environment.
+
 .. _devserver:
 
 Run the development server

--- a/tox.ini
+++ b/tox.ini
@@ -80,3 +80,9 @@ commands=
 basepython=python3.6
 commands=
     python manage.py collectstatic {posargs:--clear --noinput}
+
+# Make migrations
+[testenv:makemigrations]
+basepython=python3.6
+commands=
+    python manage.py makemigrations {posargs}


### PR DESCRIPTION
Like the "doc" env, "makemigrations" can be used to run the
makemigrations command in the correct virtual environment for
development. When run via docker-compose this has no effect and fails
due to read-only filesystem. When run locally via tox it generates the
correct migrations.