### PR TITLE
respect Django {add,change,delete}_asset permissions

### DIFF
--- a/assets/tests/test_authentication.py
+++ b/assets/tests/test_authentication.py
@@ -43,7 +43,7 @@ class OAuth2Test(TestCase):
         self.assertIsInstance(auth, dict)
 
         # user should exist
-        self.assertTrue(get_user_model().objects.filter(username='testing:test0001').exists())
+        self.assertTrue(get_user_model().objects.filter(username='testing+test0001').exists())
 
     def test_empty_subject(self):
         """A request with a good token but no subject creates no user."""

--- a/doc/administration.rst
+++ b/doc/administration.rst
@@ -1,0 +1,33 @@
+Administrator's Guide
+=====================
+
+This section has some notes on how to perform some administration tasks.
+
+Data migration from initial data
+--------------------------------
+
+The [iar-migration](https://github.com/uisautomation/iar-migration) repository
+has a set of scripts which are used to migrate asset entries from the old
+spreadsheet list into the new database.
+
+The repository contains an ``upload.py`` script which takes a series of YAML
+documents describing the asset entries to add and a token for a user to add them
+as.
+
+By default, users do not have the ability to create or edit assets outside of
+their own institution. However, the Django add, change and delete permissions
+are respected so to grant a user powers to perform a migration:
+
+1. Log into the app as the desired admin user. For example, ``spqr2``.
+
+2. Create a superuser user, e.g. ``mug99`` via ``./migrate.py createsuperuser``.
+
+3. Navigate to http://iar-backend.invalid/accounts/login and log in as the super
+   user.
+
+4. Navigate to http://iar-backend.invalid/admin and locate the ``crsid+spqr2``
+   user.
+
+5. Give that user permissions to add and edit assets.
+
+The OAuth2 token from the frontend app may now be used to upload assets.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,7 @@ If you don't know where to start then :doc:`the getting started guide
     :caption: Contents
 
     gettingstarted
+    administration
     developer
     configuration
     iarbackend


### PR DESCRIPTION
If a user already has the add_asset, change_asset and/or delete_asset permission, they should be allowed to modify any asset. This allows us to configure sufficiently privileged users to be able to administer assets.

Unfortunately this doesn't solve the machine-to-machine case as a Django user is not created when a token is presented with no subject. We should find a way to map machine users to Django users.

This change supports having the backend provide some indication to the frontend about asset permissions since the frontend cannot hope to know about administrator users.

**Edit:** Also rename Django users to use "+" as a scheme/identifier separator. Otherwise they are not valid users.