### PR TITLE
fix key used to retrieve lookup institutions from the cache

### DIFF
--- a/assets/tests/test_authentication.py
+++ b/assets/tests/test_authentication.py
@@ -26,7 +26,7 @@ class OAuth2Test(TestCase):
         # Create an empty HTTP request
         self.request = Request(HttpRequest())
         self.auth = authentication.OAuth2TokenAuthentication()
-        cache.set("testing:test0001:lookup", {}, 1000)
+        cache.set("testing+test0001:lookup", {}, 1000)
 
     def test_no_token(self):
         """A request with no token is not authenticated."""


### PR DESCRIPTION
Lookup institutions were stored in the cache based on token subject but retrieved based on username. The usernames are different from token subjects. (The former use "+" to separate scheme and identifier whereas the latter use ":".)

Fix the check and add some robustness around the lookupproxy interaction.

1. We currently (possibly incorrectly) use the bearer token presented by the user to interact with lookupproxy. Add a check that this token has the "lookup:anonymous" scope as part of token verification.

2. Check the response from lookupproxy. If it is an error response, do not cache the response and log the error.