### PR TITLE
enable auditing of asset record changes

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -1,4 +1,6 @@
 import uuid
+
+from automationcommon.models import ModelChangeMixin
 from django.db import models
 from django.db.models import Case, When, Q, BooleanField, Value
 from multiselectfield import MultiSelectField
@@ -44,7 +46,7 @@ class AssetManager(models.Manager):
         return super().get_queryset()
 
 
-class Asset(models.Model):
+class Asset(ModelChangeMixin, models.Model):
 
     """"Model to store Assets for the Information Asset Register"""
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False, db_index=True)

--- a/assets/tests/test_model.py
+++ b/assets/tests/test_model.py
@@ -1,0 +1,33 @@
+from automationcommon.models import Audit, set_local_user, clear_local_user
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from assets.models import Asset
+
+
+class AuditTest(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username='test0001')
+        set_local_user(self.user)
+        self.asset = Asset(name='test-asset')
+        self.asset.save()
+
+    def tearDown(self):
+        clear_local_user()
+
+    def test_no_audits_initially(self):
+        """With no changes, there should be no audit."""
+        self.assertEqual(Audit.objects.count(), 0)
+
+    def test_create(self):
+        """Changing an asset makes an audit record."""
+        old_name = self.asset.name
+        self.asset.name = 'new-name'
+        self.asset.save()
+        self.assertEqual(Audit.objects.count(), 1)
+        audit = Audit.objects.filter(model_pk=repr(self.asset.pk)).first()
+        self.assertIsNotNone(audit)
+        self.assertEqual(audit.field, 'name')
+        self.assertEqual(audit.old, old_name)
+        self.assertEqual(audit.new, self.asset.name)
+        self.assertEqual(audit.who.pk, self.user.pk)

--- a/assets/views.py
+++ b/assets/views.py
@@ -4,6 +4,8 @@ Views for the assets application.
 """
 import logging
 
+from automationcommon.models import set_local_user, clear_local_user
+
 from django.core.cache import cache
 from django.db.models import Q
 from django.utils.decorators import method_decorator
@@ -102,6 +104,23 @@ class AssetViewSet(viewsets.ModelViewSet):
     # forward, we need to decide on a better permissions model based on the (client, scope, user)
     # triple.
     permission_classes = (HasScopesPermission,)
+
+    def initial(self, request, *args, **kwargs):
+        """Runs anything that needs to occur prior to calling the method handler."""
+        # Perform any authentication, permissions checking etc.
+        super().initial(request, *args, **kwargs)
+
+        # Set the local user for the auditing framework
+        set_local_user(request.user)
+
+    def finalize_response(self, request, response, *args, **kwargs):
+        """
+        Returns the final response object.
+        """
+        # By this time the local user has been recorded if necessary.
+        clear_local_user()
+
+        return super().finalize_response(request, response, *args, **kwargs)
 
     def get_queryset(self):
         """get_queryset is patched to only return those assets that are not private or that are

--- a/iarbackend/settings/base.py
+++ b/iarbackend/settings/base.py
@@ -45,6 +45,11 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # NB: this middleware only records the user signed in through the usual Django session. It does
+    # *not* record the user which is created from an OAuth2 token as part of the authentication for
+    # the API. We set this explicitly in the APIView in assets.views.
+    'automationcommon.middleware.RequestUserMiddleware',
 ]
 
 #: Root URL patterns


### PR DESCRIPTION
**IMPORTANT** Requires uisautomation/django-automationcommon#6 to be merged first.

Enable the auditing support from automation common.

Closes #36.