### PR TITLE
improve logging in development

### DIFF
--- a/iarbackend/settings/developer.py
+++ b/iarbackend/settings/developer.py
@@ -74,3 +74,21 @@ else:
     # Set the OAuth2 authorisation endpoint
     SWAGGER_SETTINGS['SECURITY_DEFINITIONS']['oauth2']['authorizationUrl'] = (  # noqa: F405
     'http://localhost:4444/oauth2/auth')
+
+# Ensure that logging is shown in the console.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}


### PR DESCRIPTION
Only logging from loggers in the 'django' hierarchy are shown with the default logging configuration. Add configuration in development which logs all output at the INFO level. This is useful when developing the app but obviously should not be enabled in production.

[1] https://docs.djangoproject.com/en/2.0/topics/logging/#default-logging-configuration