### PR TITLE
add retries to OAuth2 HTTP(S) requests

### DIFF
--- a/assets/defaultsettings.py
+++ b/assets/defaultsettings.py
@@ -48,6 +48,13 @@ List of OAuth2 scopes the API server will request for the token it will use with
 
 """
 
+ASSETS_OAUTH2_MAX_RETRIES = 5
+"""
+Maximum number of retries when fetching URLs from the OAuth2 endpoint or OAuth2 authenticated URLs.
+This applies only to failed DNS lookups, socket connections and connection timeouts, never to
+requests where data has made it to the server.
+"""
+
 LOOKUP_ROOT = None
 """
 URL of the lookup proxy's API root.

--- a/assets/oauth2client.py
+++ b/assets/oauth2client.py
@@ -5,6 +5,7 @@ which is pre-authorised with an OAuth2 client token.
 """
 from django.conf import settings
 from requests_oauthlib import OAuth2Session
+from requests.adapters import HTTPAdapter
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
 
 
@@ -30,6 +31,9 @@ class AuthenticatedSession:
         """
         client = BackendApplicationClient(client_id=settings.ASSETS_OAUTH2_CLIENT_ID)
         session = OAuth2Session(client=client)
+        adapter = HTTPAdapter(max_retries=settings.ASSETS_OAUTH2_MAX_RETRIES)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
         session.fetch_token(
             timeout=2, token_url=settings.ASSETS_OAUTH2_TOKEN_URL,
             client_id=settings.ASSETS_OAUTH2_CLIENT_ID,


### PR DESCRIPTION
Add a configurable number of retry attempts when fetching tokens from the OAuth2 endpoint or when requesting resources authorised with OAuth2 tokens.

This uses requests' built-in retry behaviour which retries only in the face of network errors such as DNS failures or connection errors. It does not retry if data has made it to the server.

It is, unfortunately, non-trivial to write a test for this since faking a network error requires deeper knowledge of requests internals than I possess. We rely on the max_retries parameter behaving as documented.

Closes #52.