### PR TITLE
explicitly set postgres image versions to match GCloud version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     <<: *devserver
     command: ["shell"]
   iar-db:
-    image: postgres
+    image: postgres:9.6
     env_file:
       - compose/base.env
 
@@ -64,7 +64,7 @@ services:
     env_file:
       - compose/lookupproxy.env
   lookupproxy-db:
-    image: postgres
+    image: postgres:9.6
     env_file:
       - compose/lookupproxy.env
 
@@ -89,7 +89,7 @@ services:
     volumes:
       - "./compose/start-hydra.sh:/tmp/start-hydra.sh/:ro"
   hydra-db:
-    image: postgres
+    image: postgres:9.6
     env_file:
       - compose/hydra.env
 


### PR DESCRIPTION
Our GCloud deployment uses PostgreSQL 9.6 and the latest images at version 10. We should try to make sure we use the same version of the database in local development as we do in production.