### PR TITLE
lookup.get_person_for_user: return cached result earlier

### DIFF
--- a/assets/lookup.py
+++ b/assets/lookup.py
@@ -41,14 +41,14 @@ def get_person_for_user(user):
     if user.is_anonymous:
         raise LookupError('User is anonymous')
 
-    # check the user has an associated lookup identity
-    if not UserLookup.objects.filter(user=user).exists():
-        raise LookupError('User has no lookup identity')
-
     # return a cached response if we have it
     cached_resource = cache.get("{user.username}:lookup".format(user=user))
     if cached_resource is not None:
         return cached_resource
+
+    # check the user has an associated lookup identity
+    if not UserLookup.objects.filter(user=user).exists():
+        raise LookupError('User has no lookup identity')
 
     # Extract the scheme and identifier for the token
     scheme = user.lookup.scheme


### PR DESCRIPTION
We inadvertently returned the cached return value for get_person_for_user *after* touching the database, not before.

Installing the silk profiler revealed that for each index request we were make 382 queries to the database when using a copy of database with ~1000 assets. This took around 200ms.

By re-ordering these statements, we have reduced the number of database queries to 5 which took around 10ms.

This is a 20x speedup.

I suggest we use silk going forward :).

Closes uisautomation/iar-deploy#25