### PR TITLE
add middleware to log HTTP 400 errors

### DIFF
--- a/assets/middleware.py
+++ b/assets/middleware.py
@@ -1,0 +1,23 @@
+import logging
+
+
+LOG = logging.getLogger(__name__)
+
+
+class LogHttp400Errors:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if response.status_code == 400:
+            LOG.warn('400 response from following request:')
+            LOG.warn('%r', request)
+            LOG.warn('Request body was:')
+            LOG.warn('%r', request.body)
+            LOG.warn('Response was:')
+            LOG.warn('%r', response)
+            LOG.warn('Response body was:')
+            LOG.warn('%r', response.content)
+
+        return response

--- a/iarbackend/settings/base.py
+++ b/iarbackend/settings/base.py
@@ -50,6 +50,8 @@ MIDDLEWARE = [
     # *not* record the user which is created from an OAuth2 token as part of the authentication for
     # the API. We set this explicitly in the APIView in assets.views.
     'automationcommon.middleware.RequestUserMiddleware',
+
+    'assets.middleware.LogHttp400Errors',
 ]
 
 #: Root URL patterns


### PR DESCRIPTION
To aid in debugging, it is useful to log to the console the requests which cause HTTP 400 responses to be returned and the response body itself.

Add a simple middleware which intercepts HTTP errors and logs the required information.

This PR has a corresponding PR at uisautomation/iar-deploy#32 which updates the logging configuration in the deployment.