### PR TITLE
Re-work asset stats endpoint

### DIFF
--- a/assets/models.py
+++ b/assets/models.py
@@ -12,7 +12,11 @@ class AssetManager(models.Manager):
     annotation reflects whether the asset record is "complete" as defined in the requirements."""
     def get_queryset(self):
         """A QuerySet to add an annotation to specify if an Asset is complete or not"""
-        return self.get_base_queryset().annotate(is_complete=Case(When(Q(
+        return self.annotate_is_complete(self.get_base_queryset())
+
+    def annotate_is_complete(self, queryset):
+        """Add an annotation to a queryset to specify if an Asset is complete or not"""
+        return queryset.annotate(is_complete=Case(When(Q(
             Q(name__isnull=False),
             Q(department__isnull=False),
             Q(purpose__isnull=False),

--- a/assets/serializers.py
+++ b/assets/serializers.py
@@ -81,22 +81,24 @@ class AssetDeptStatsSerializer(serializers.Serializer):
         'Number of assets hold by the department'))
 
 
+class AssetCountsSerializer(serializers.Serializer):
+    """
+    Serialise a :py:class:`assets.views.AssetCounts` object.
+    """
+    total = serializers.IntegerField(help_text='Total number of asset entries')
+    completed = serializers.IntegerField(help_text='Total number of completed asset entries')
+    with_personal_data = serializers.IntegerField(
+        help_text='Total number of asset entries for assets with personal data')
+
+
 class AssetStatsSerializer(serializers.Serializer):
     """
-    Asset Stats serializer
+    Serialise a :py:class:`assets.views.AssetStats` object.
     """
-    total_assets = serializers.IntegerField(help_text=(
-        'Total number of assets'))
-    total_assets_completed = serializers.IntegerField(help_text=(
-        'Total number of completed assets'))
-    total_assets_personal_data = serializers.IntegerField(help_text=(
-        'Total number of assets containing personal data'))
-    total_assets_dept = AssetDeptStatsSerializer(many=True, help_text=(
-        'Total number of assets separated by department.'))
-    total_assets_dept_completed = AssetDeptStatsSerializer(many=True, help_text=(
-        'Total number of completed assets separated by department.'))
-    total_assets_dept_personal_data = AssetDeptStatsSerializer(many=True, help_text=(
-        'Total number of assets containing personal data separated by department.'))
+    all = AssetCountsSerializer(help_text='Statistics for all asset entries')
+    by_institution = serializers.DictField(
+        child=AssetCountsSerializer(),
+        help_text='Statistics for asset entries grouped by Lookup instid')
 
 
 @contextlib.contextmanager

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -8,6 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.timezone import now
 from rest_framework.test import APIClient
 from assets.models import Asset
 from assets.serializers import AssetSerializer
@@ -432,6 +433,7 @@ class APIViewsTests(TestCase):
 
     def test_asset_stats(self):
         """The asset stats endpoint reports correct statistics."""
+        set_local_user(self.user)  # Some user which will be used in the audit log
 
         # A complete asset
         self.create_asset_from_dict(COMPLETE_ASSET)
@@ -445,6 +447,11 @@ class APIViewsTests(TestCase):
         self.create_asset_from_dict(merge_dicts(
             COMPLETE_ASSET, {'department': 'TESTDEPT2'}
         ))
+
+        # A deleted asset
+        asset = self.create_asset_from_dict(COMPLETE_ASSET)
+        asset.deleted_at = now()
+        asset.save()
 
         # Retrieve the stats
         client = APIClient()

--- a/assets/tests/test_views.py
+++ b/assets/tests/test_views.py
@@ -458,15 +458,11 @@ class APIViewsTests(TestCase):
         response = client.get('/stats', format='json')
 
         self.assertDictEqual(json.loads(response.content), {
-            'total_assets': 3,
-            'total_assets_completed': 2,
-            'total_assets_personal_data': 2,
-            'total_assets_dept': [{'department': 'TESTDEPT', 'num_assets': 2},
-                                  {'department': 'TESTDEPT2', 'num_assets': 1}],
-            'total_assets_dept_completed': [{'department': 'TESTDEPT', 'num_assets': 1},
-                                            {'department': 'TESTDEPT2', 'num_assets': 1}],
-            'total_assets_dept_personal_data': [{'department': 'TESTDEPT', 'num_assets': 1},
-                                                {'department': 'TESTDEPT2', 'num_assets': 1}],
+            'all': {'total': 3, 'completed': 2, 'with_personal_data': 2},
+            'by_institution': {
+                'TESTDEPT': {'total': 2, 'completed': 1, 'with_personal_data': 1},
+                'TESTDEPT2': {'total': 1, 'completed': 1, 'with_personal_data': 1},
+            },
         })
 
     def refresh_user(self):

--- a/assets/views.py
+++ b/assets/views.py
@@ -1,6 +1,7 @@
 """
 Views for the assets application.
 """
+from collections import namedtuple
 from automationlookup.lookup import get_person_for_user
 from automationcommon.models import set_local_user, clear_local_user
 from automationoauthdrf.authentication import OAuth2TokenAuthentication
@@ -189,6 +190,71 @@ class AssetViewSet(viewsets.ModelViewSet):
             instance.save()
 
 
+AssetCounts = namedtuple('AssetCounts', 'total completed with_personal_data')
+
+
+class AssetStats:
+    """Given a queryset of matching non-annotated asset records, calculate some statistics for all
+    assets and assets grouped by department.
+    We need the non-annotated queryset to work around a bug in Django. See
+    https://code.djangoproject.com/ticket/28762 and
+    https://github.com/uisautomation/iar-backend/issues/55.
+
+    :param queryset: Non-annotated queryset of :py:class:`assets.models.Asset` objects
+
+    :ivar AssetCounts all: Counts for all assets
+    :ivar dict by_institution: An :py:class:`AssetCounts` instance for each institution keyed by
+        Lookup instid.
+
+    """
+
+    def __init__(self, queryset):
+        # Annotate the input queryset with is_complete.
+        annotated_queryset = Asset.objects.annotate_is_complete(queryset)
+
+        # Compute asset entry counts for all assets.
+        self.all = AssetCounts(
+            total=queryset.count(),
+            # This works around bug that throws an exception
+            completed=queryset.filter(
+                id__in=annotated_queryset.filter(is_complete=True).values('id')).count(),
+            with_personal_data=queryset.filter(personal_data=True).count()
+        )
+
+        # Compute individual counts grouped by department for each class of entry.
+        n_assets_by_dept = {
+            d['department']: d['count'] for d in
+            queryset.values('department').annotate(count=Count('id')).order_by('department')
+        }
+        n_assets_completed_by_dept = {
+            d['department']: d['count'] for d in
+            annotated_queryset.filter(is_complete=True).values('department')
+            .annotate(count=Count('id')).order_by('department')
+        }
+        n_assets_with_personal_data_by_dept = {
+            d['department']: d['count'] for d in
+            queryset.filter(personal_data=True)
+            .values('department').annotate(count=Count('id')).order_by('department')
+        }
+
+        # Create a list of all departments in the database
+        all_depts = [
+            row['department'] for row in
+            queryset.distinct('department').values('department').order_by('department')
+        ]
+
+        # Collect separate counts together grouped by institution. If there is no count for a
+        # particular institution, report "0".
+        self.by_institution = {
+            dept: AssetCounts(
+                total=n_assets_by_dept.get(dept, 0),
+                completed=n_assets_completed_by_dept.get(dept, 0),
+                with_personal_data=n_assets_with_personal_data_by_dept.get(dept, 0),
+            )
+            for dept in all_depts
+        }
+
+
 class Stats(generics.RetrieveAPIView):
     """
     Returns Assets stats: total number of assets, total number of assets completed,
@@ -199,35 +265,4 @@ class Stats(generics.RetrieveAPIView):
 
     def get_object(self):
         # These statistics should only be for non-deleted assets.
-        non_deleted_assets = Asset.objects.get_base_queryset().filter(deleted_at__isnull=True)
-        non_deleted_annotated_assets = Asset.objects.filter(deleted_at__isnull=True)
-
-        # The total number of assets
-        total_assets = non_deleted_assets.count()
-
-        # This is highly inefficient but it's trying to bypass a bug that throws an exception
-        # https://code.djangoproject.com/ticket/28762 and
-        # https://github.com/uisautomation/iar-backend/issues/55
-        total_assets_completed = non_deleted_assets.filter(
-            id__in=non_deleted_annotated_assets.filter(is_complete=True).values('id')).count()
-
-        total_assets_personal_data = non_deleted_assets.filter(personal_data=True).count()
-        total_assets_dept = (non_deleted_assets.values('department')
-                             .annotate(num_assets=Count('id')).order_by('department'))
-        total_assets_dept_completed = (
-            non_deleted_annotated_assets.filter(is_complete=True).values('department')
-            .annotate(num_assets=Count('id')).order_by('department')
-        )
-        total_assets_dept_personal_data = (
-            non_deleted_assets.filter(personal_data=True)
-            .values('department').annotate(num_assets=Count('id')).order_by('department')
-        )
-
-        return {
-            'total_assets': total_assets,
-            'total_assets_completed': total_assets_completed,
-            'total_assets_personal_data': total_assets_personal_data,
-            'total_assets_dept': total_assets_dept,
-            'total_assets_dept_completed': total_assets_dept_completed,
-            'total_assets_dept_personal_data': total_assets_dept_personal_data
-        }
+        return AssetStats(Asset.objects.get_base_queryset().filter(deleted_at__isnull=True))


### PR DESCRIPTION
This PR re-works the stats endpoint as outlined in #84 and #85. Commit a64b500 merely tidies up the existing test a little by directly creating the Asset entries in the database rather than having the boilerplate of going through the API. Commit e9081e6 addresses #84 by excluding deleted assets from the returned stats. Commit abc0193 builds on this work and re-arranges the results from the stats endpoint to have the grouping outlined in #85.

Closes #84. Closes #85.